### PR TITLE
Add python 3.11 support

### DIFF
--- a/dev-python/python-btrfs/python-btrfs-13.ebuild
+++ b/dev-python/python-btrfs/python-btrfs-13.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{6..10} )
+PYTHON_COMPAT=( python3_{6..11} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
As far as I can tell, python-btrfs works fine with Python-3.11, so update `PYTHON_COMPAT` variable accordingly.